### PR TITLE
Tracking `item.timebase.rate` is `real` rate of the video playback

### DIFF
--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -67,7 +67,6 @@ extension Renderer {
     public typealias Dispatch = (Event) -> Void
     
     public enum Event {
-        case playbackReady
         case playbackStarted
         case playbackStopped
         case playbackFinished

--- a/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
@@ -114,12 +114,9 @@ public class SphereVideoStreamViewController: GLKViewController, RendererProtoco
                                 return error
                             }()
                             self?.dispatch?(.playbackFailed(error))
-                        case .readyToPlay:
-                            self?.dispatch?(.playbackReady)
                         default: break
                         }
-                    case .didChangeRate(let old, let new):
-                        guard new != old else { return }
+                    case .didChangeRate(let new):
                         if new == 0 { self?.dispatch?(.playbackStopped) }
                         else { self?.dispatch?(.playbackStarted) }
                     case .didChangeItemDuration(_, let new):

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -153,12 +153,9 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                                 return error
                             }()
                             self?.dispatch?(.playbackFailed(error))
-                        case .readyToPlay:
-                            self?.dispatch?(.playbackReady)
                         default: break
                         }
-                    case .didChangeRate(let old, let new):
-                        guard new != old else { return }
+                    case .didChangeRate(let new):
                         if new == 0 { self?.dispatch?(.playbackStopped) }
                         else { self?.dispatch?(.playbackStarted) }
                     case .didChangeItemDuration(_, let new):


### PR DESCRIPTION
Using information from following session: 
[ASCIIWWDC](http://asciiwwdc.com/2016/sessions/503?q=timebase)
[Advances in AVFoundation Playback](https://developer.apple.com/videos/play/wwdc2016/503/)

We should use `AVPlayerItem.timebase.rate` to track when player is really playing.
Dropping couple of unnecessary observing keypathes.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-100)