### PR TITLE
Added AVPlayer rate observing

### DIFF
--- a/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
@@ -116,7 +116,7 @@ public class SphereVideoStreamViewController: GLKViewController, RendererProtoco
                             self?.dispatch?(.playbackFailed(error))
                         default: break
                         }
-                    case .didChangeRate(let new):
+                    case .didChangeTimebaseRate(let new):
                         if new == 0 { self?.dispatch?(.playbackStopped) }
                         else { self?.dispatch?(.playbackStarted) }
                     case .didChangeItemDuration(_, let new):

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -155,7 +155,7 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                             self?.dispatch?(.playbackFailed(error))
                         default: break
                         }
-                    case .didChangeRate(let new):
+                    case .didChangeTimebaseRate(let new):
                         if new == 0 { self?.dispatch?(.playbackStopped) }
                         else { self?.dispatch?(.playbackStarted) }
                     case .didChangeItemDuration(_, let new):


### PR DESCRIPTION
@aol-public/mobile-sdk-team: Ready for review.

Related to [PR](https://github.com/vidible/mobile-sdk-ios/pull/569)

There is a need to observe changing of `AVPlayer.rate` changes for tvOS, because of play/pause button on remote control changes rate of active `AVPlayer` under the hood.
