### PR TITLE
Duration now loaded asynchronously from asset

### DIFF
--- a/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
@@ -119,8 +119,7 @@ public class SphereVideoStreamViewController: GLKViewController, RendererProtoco
                     case .didChangeTimebaseRate(let new):
                         if new == 0 { self?.dispatch?(.playbackStopped) }
                         else { self?.dispatch?(.playbackStarted) }
-                    case .didChangeItemDuration(_, let new):
-                        guard let new = new else { return }
+                    case .didChangeItemDuration(let new):
                         self?.dispatch?(.durationReceived(new))
                     case .didFinishPlayback:
                         self?.dispatch?(.playbackFinished)

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -165,8 +165,7 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                     case .didChangeTimebaseRate(let new):
                         if new == 0 { self?.dispatch?(.playbackStopped) }
                         else { self?.dispatch?(.playbackStarted) }
-                    case .didChangeItemDuration(_, let new):
-                        guard let new = new else { return }
+                    case .didChangeItemDuration(let new):
                         self?.dispatch?(.durationReceived(new))
                     case .didFinishPlayback:
                         self?.dispatch?(.playbackFinished)


### PR DESCRIPTION
@aol-public/mobile-sdk-team: Ready for review.

In PR was changed way to define video duration. Now it loads from AVAsset asynchronously.