### PR TITLE
Loaded `duration` is passed to `Player`

### DIFF
--- a/VideoRenderer/VideoRenderer/SystemPlayerObserver.swift
+++ b/VideoRenderer/VideoRenderer/SystemPlayerObserver.swift
@@ -202,10 +202,17 @@ public final class SystemPlayerObserver: NSObject {
             emit(.didChangeAsset(asset))
             
             let key = "duration"
-            asset.loadValuesAsynchronously(forKeys: [key]) { [weak self] in
-                let status = asset.statusOfValue(forKey: key, error: nil)
-                guard case .loaded = status else { return }
-                self?.emit(.didChangeItemDuration(to: asset.duration))
+            let status = asset.statusOfValue(forKey: key, error: nil)
+            switch status {
+            case .unknown:
+                asset.loadValuesAsynchronously(forKeys: [key]) { [weak self] in
+                    let status = asset.statusOfValue(forKey: key, error: nil)
+                    guard case .loaded = status else { return }
+                    self?.emit(.didChangeItemDuration(to: asset.duration))
+                }
+            case .loaded:
+                emit(.didChangeItemDuration(to: asset.duration))
+            default: break
             }
             
         default:

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -109,7 +109,15 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                     player?.removeTimeObserver(timeObserver)
                 }
                 
-                player?.currentItem?.asset.cancelLoading()
+                if let asset = player?.currentItem?.asset {
+                    let durationStatus = asset.statusOfValue(forKey: "duration", error: nil)
+                    let mediaOptionsStatus = asset.statusOfValue(forKey: "availableMediaCharacteristicsWithMediaSelectionOptions", error: nil)
+                    switch (durationStatus, mediaOptionsStatus) {
+                    case (.loading, .loading):
+                        asset.cancelLoading()
+                    default: break
+                    }
+                }
                 player?.replaceCurrentItem(with: nil)
                 player = nil
                 observer = nil


### PR DESCRIPTION
@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-266)
