### PR TITLE
Fix video time tracking

### DIFF
--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -44,7 +44,7 @@ extension Renderer {
         public var content: URL
         public var rate: Float
         public var volume: Float
-        public var newTime: CMTime?
+        public var currentTime: CMTime?
         public var pictureInPictureActive: Bool
         public var audible: MediaSelection
         public var legible: MediaSelection
@@ -59,7 +59,7 @@ extension Renderer {
                     content: URL,
                     rate: Float,
                     volume: Float,
-                    newTime: CMTime?,
+                    currentTime: CMTime?,
                     pictureInPictureActive: Bool,
                     audible: MediaSelection,
                     legible: MediaSelection) {
@@ -67,7 +67,7 @@ extension Renderer {
             self.content = content
             self.rate = rate
             self.volume = volume
-            self.newTime = newTime
+            self.currentTime = currentTime
             self.pictureInPictureActive = pictureInPictureActive
             self.audible = audible
             self.legible = legible

--- a/VideoRenderer/VideoRenderer/SeekerController.swift
+++ b/VideoRenderer/VideoRenderer/SeekerController.swift
@@ -11,12 +11,15 @@ public final class SeekerController {
         self.player = player
     }
     
+    var currentTime: CMTime?
     private var newTime: CMTime?
     private var activeSeekingTime: CMTime?
     
     public func process(to newTime: CMTime?) {
         guard self.newTime != newTime else { return }
+        guard self.currentTime != newTime else { return }
         self.newTime = newTime
+        self.currentTime = newTime
         
         guard let time = newTime else { return }
         guard activeSeekingTime == nil else { return }

--- a/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
@@ -151,7 +151,7 @@ public class SphereVideoStreamViewController: GLKViewController, RendererProtoco
             
             guard currentPlayer.currentItem?.status == .readyToPlay else { return }
             
-            seekerController?.process(to: props.newTime)
+            seekerController?.process(to: props.currentTime)
             
             if timeObserver == nil {
                 timeObserver = currentPlayer.addPeriodicTimeObserver(

--- a/VideoRenderer/VideoRenderer/SystemPlayerObserver.swift
+++ b/VideoRenderer/VideoRenderer/SystemPlayerObserver.swift
@@ -203,10 +203,11 @@ public final class SystemPlayerObserver: NSObject {
             
             new.loadValuesAsynchronously(forKeys: [#keyPath(AVAsset.duration)],
                                          completionHandler: { [weak self] in
-                    guard case .loaded = new.statusOfValue(forKey: #keyPath(AVAsset.duration),
-                                                           error: nil) else { return }
-                    self?.emit(.didChangeItemDuration(to: new.duration))
+                                            guard case .loaded = new.statusOfValue(forKey: #keyPath(AVAsset.duration),
+                                                                                   error: nil) else { return }
+                                            self?.emit(.didChangeItemDuration(to: new.duration))
             })
+            
         default:
             super.observeValue(
                 forKeyPath: keyPath,

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -245,13 +245,14 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
             //                allowHorizontalBars: props.allowHorizontalBars
             //            )
             
-            seekerController?.process(to: props.newTime)
+            seekerController?.process(to: props.currentTime)
             
             if timeObserver == nil {
                 timeObserver = currentPlayer.addPeriodicTimeObserver(
                     forInterval: CMTime(seconds: 0.2, preferredTimescale: 600),
                     queue: nil,
                     using: { [weak self] time in
+                        self?.seekerController?.currentTime = time
                         self?.dispatch?(.currentTimeUpdated(time))
                 })
             }


### PR DESCRIPTION
Use `currentTime` instead `newTime` and `changeReason`

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-XXXX)
