### PR TITLE
Fix player mute

### DIFF
--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -43,7 +43,7 @@ extension Renderer {
         public var angles: (vertical: Float, horizontal: Float)
         public var content: URL
         public var rate: Float
-        public var volume: Float
+        public var isMuted: Bool
         public var currentTime: CMTime?
         public var pictureInPictureActive: Bool
         public var allowsExternalPlayback: Bool
@@ -59,7 +59,7 @@ extension Renderer {
         public init(angles: (vertical: Float, horizontal: Float),
                     content: URL,
                     rate: Float,
-                    volume: Float,
+                    isMuted: Bool,
                     currentTime: CMTime?,
                     pictureInPictureActive: Bool,
                     allowsExternalPlayback: Bool,
@@ -68,7 +68,7 @@ extension Renderer {
             self.angles = angles
             self.content = content
             self.rate = rate
-            self.volume = volume
+            self.isMuted = isMuted
             self.currentTime = currentTime
             self.pictureInPictureActive = pictureInPictureActive
             self.allowsExternalPlayback = allowsExternalPlayback

--- a/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/SphereVideoStreamViewController.swift
@@ -157,7 +157,7 @@ public class SphereVideoStreamViewController: GLKViewController, RendererProtoco
                 })
             }
             
-            currentPlayer.volume = props.volume
+            currentPlayer.isMuted = props.isMuted
             
             if currentPlayer.rate != props.rate {
                 currentPlayer.rate = props.rate

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -255,7 +255,7 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                 })
             }
             
-            currentPlayer.volume = props.volume
+            currentPlayer.isMuted = props.isMuted
             
             if currentPlayer.rate != props.rate {
                 currentPlayer.rate = props.rate


### PR DESCRIPTION
AVPlayer has `isMuted` property. For supporting mute on external device `isMuted` should be set instead `volume`.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-421)
