### PR TITLE
Disabling this because it `allowsExternalPlayback` gets caught in thread trap and never finishes executing

### DIFF
--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -234,7 +234,9 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                 }
             }
             
-            currentPlayer.allowsExternalPlayback = props.allowsExternalPlayback
+            if currentPlayer.allowsExternalPlayback != props.allowsExternalPlayback {
+                currentPlayer.allowsExternalPlayback = props.allowsExternalPlayback
+            }
             
             guard currentPlayer.currentItem?.status == .readyToPlay else { return }
             


### PR DESCRIPTION
[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-429)

@BogdanBilonog Do you have an idea how to fix this?
