### PR TITLE
Rework subtitles to UUID representation.

### DIFF
--- a/VideoRenderer/VideoRenderer.xcodeproj/project.pbxproj
+++ b/VideoRenderer/VideoRenderer.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		DEA993BF1E83FF1D00EB3B8A /* SphereVideoStreamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA993BC1E83FF1D00EB3B8A /* SphereVideoStreamViewController.swift */; };
 		DEA993C01E83FF5300EB3B8A /* VideoGravityStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA993AE1E83FEF300EB3B8A /* VideoGravityStrategyTests.swift */; };
 		DEA993C21E83FF8200EB3B8A /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA993C11E83FF8200EB3B8A /* Action.swift */; };
+		DED8F33A1FBB34E1005BA836 /* MediaCharacteristicRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED8F3391FBB34E1005BA836 /* MediaCharacteristicRenderer.swift */; };
 		FEBAC92A1F1666D00012E519 /* PictureInPictureControllerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBAC9291F1666D00012E519 /* PictureInPictureControllerObserver.swift */; };
 /* End PBXBuildFile section */
 
@@ -52,6 +53,7 @@
 		DEA993BB1E83FF1D00EB3B8A /* Camera.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		DEA993BC1E83FF1D00EB3B8A /* SphereVideoStreamViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SphereVideoStreamViewController.swift; sourceTree = "<group>"; };
 		DEA993C11E83FF8200EB3B8A /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		DED8F3391FBB34E1005BA836 /* MediaCharacteristicRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCharacteristicRenderer.swift; sourceTree = "<group>"; };
 		FEBAC9291F1666D00012E519 /* PictureInPictureControllerObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PictureInPictureControllerObserver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -103,6 +105,7 @@
 				DEA993AE1E83FEF300EB3B8A /* VideoGravityStrategyTests.swift */,
 				DEA993871E83FE0600EB3B8A /* VideoRenderer.h */,
 				DEA993B41E83FF0900EB3B8A /* VideoStreamViewController.swift */,
+				DED8F3391FBB34E1005BA836 /* MediaCharacteristicRenderer.swift */,
 				DEA993B51E83FF0900EB3B8A /* SeekerController.swift */,
 				DEA993B61E83FF0900EB3B8A /* ContentRendererViewController.swift */,
 				DEA993BA1E83FF1D00EB3B8A /* SphereView.swift */,
@@ -243,6 +246,7 @@
 				DEA993B21E83FEF300EB3B8A /* SystemPlayerObserver.swift in Sources */,
 				DEA993BE1E83FF1D00EB3B8A /* Camera.swift in Sources */,
 				DEA993BD1E83FF1D00EB3B8A /* SphereView.swift in Sources */,
+				DED8F33A1FBB34E1005BA836 /* MediaCharacteristicRenderer.swift in Sources */,
 				DEA993B81E83FF0900EB3B8A /* SeekerController.swift in Sources */,
 				DEA993B91E83FF0900EB3B8A /* ContentRendererViewController.swift in Sources */,
 				DEA993BF1E83FF1D00EB3B8A /* SphereVideoStreamViewController.swift in Sources */,

--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -85,9 +85,10 @@ class MediaCharacteristicRenderer {
                         (Option(name: option.displayName), option)
                     }
                     
-                    let legibleOptionsPairs = legibleOptions.map { option in
+                    var legibleOptionsPairs = legibleOptions.map { option in
                         (Option(name: option.displayName), option)
                     }
+                    legibleOptionsPairs.insert((Option(name: "None"), AVMediaSelectionOption()), at: 0)
                     
                     self.mediaOptionCache = MediaOptionCache(
                         item: item,
@@ -110,10 +111,8 @@ class MediaCharacteristicRenderer {
                         $0.1 != selectedLegibleOption
                     }
                     
-                    let selectedLegibleOptionsPair = legibleOptionsPairs.first {
-                        $0.1 == selectedLegibleOption
-                    }
-                    
+                    // Selected 'None' as default
+                    let selectedLegibleOptionsPair = legibleOptionsPairs.first
                     
                     let availableOptions = AvailableMediaOptions(
                         unselectedAudibleOptions: unselectedAudibleOptionsPairs.map(first),

--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -1,0 +1,149 @@
+//  Copyright © 2016 One by Aol : Publishers. All rights reserved.
+
+import AVFoundation
+
+private let assetKey = "availableMediaCharacteristicsWithMediaSelectionOptions"
+
+public protocol UUIDPhantom: Hashable {
+    var uuid: UUID { get }
+}
+
+extension UUIDPhantom {
+    public var hashValue: Int { return uuid.hashValue }
+    public static func ==(left: Self, right: Self) -> Bool {
+        return left.uuid == right.uuid
+    }
+}
+
+func first<T, U>(pair: (T, U)) -> T { return pair.0 }
+func second<T, U>(pair: (T, U)) -> U { return pair.1 }
+
+public struct AudibleOption: UUIDPhantom {
+    public let uuid = UUID()
+    public let name: String
+}
+
+public struct LegibleOption: UUIDPhantom {
+    public let uuid = UUID()
+    public let name: String
+}
+
+public struct AvailableMediaOptions {
+    let unselectedAudibleOptions: [AudibleOption]
+    let selectedAudibleOption: AudibleOption?
+    let unselectedLegibleOptions: [LegibleOption]
+    let selectedLegibleOption: LegibleOption?
+}
+
+class MediaCharacteristicRenderer {
+    
+    struct Props {
+        let item: AVPlayerItem
+        let didStartMediaOptionsDiscovery: () -> ()
+        let didDiscoverMediaOptions: (AvailableMediaOptions) -> ()
+        let selectedAudibleOption: AudibleOption?
+        let selectedLegibleOption: LegibleOption?
+    }
+    
+    struct MediaOptionCache {
+        let item: AVPlayerItem
+        var audibleOptions: [AudibleOption: AVMediaSelectionOption] = [:]
+        var legibleOptions: [LegibleOption: AVMediaSelectionOption] = [:]
+    }
+    
+    var mediaOptionCache: MediaOptionCache?
+    
+    var props: Props? {
+        didSet {
+            /// Verify that we have item to look for
+            guard let item = props?.item else {
+                self.mediaOptionCache = nil
+                return
+            }
+            
+            if item != mediaOptionCache?.item { mediaOptionCache = nil }
+            
+            switch item.asset.statusOfValue(forKey: assetKey, error: nil) {
+            /// Load options
+            case .unknown:
+                props?.didStartMediaOptionsDiscovery()
+                item.asset.loadValuesAsynchronously(forKeys: [assetKey]) {
+                    // Ignore results that are not actual anymore
+                    guard self.props?.item == item else { return }
+                    
+                    let status = item.asset.statusOfValue(forKey: assetKey, error: nil)
+                    // Ignore failed results
+                    guard case .loaded = status else { return }
+                    
+                    let audibleGroup = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristicAudible)
+                    let legibleGroup = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristicLegible)
+                    
+                    let audibleOptions = audibleGroup?.options ?? []
+                    let legibleOptions = legibleGroup?.options.filter(AVMediaSelectionOption.hasLanguageTag) ?? []
+                    
+                    let audibleOptionsPairs = audibleOptions.map { option in
+                        (AudibleOption(name: option.displayName), option)
+                    }
+                    
+                    let legibleOptionsPairs = legibleOptions.map { option in
+                        (LegibleOption(name: option.displayName), option)
+                    }
+                    
+                    self.mediaOptionCache = MediaOptionCache(
+                        item: item,
+                        audibleOptions: Dictionary(uniqueKeysWithValues: audibleOptionsPairs),
+                        legibleOptions: Dictionary(uniqueKeysWithValues: legibleOptionsPairs)
+                    )
+                    
+                    let selectedAudibleOption = audibleGroup.flatMap { item.selectedMediaOption(in: $0) }
+                    let selectedLegibleOption = legibleGroup.flatMap { item.selectedMediaOption(in: $0) }
+                    
+                    let unselectedAudibleOptionsPairs = audibleOptionsPairs.filter {
+                        $0.1 != selectedAudibleOption
+                    }
+                    
+                    let selectedAudibleOptionPair = audibleOptionsPairs.first {
+                        $0.1 == selectedAudibleOption
+                    }
+                    
+                    let unselectedLegibleOptionsPairs = legibleOptionsPairs.filter {
+                        $0.1 != selectedLegibleOption
+                    }
+                    
+                    let selectedLegibleOptionsPair = legibleOptionsPairs.first {
+                        $0.1 == selectedLegibleOption
+                    }
+                    
+                    
+                    let availableOptions = AvailableMediaOptions(
+                        unselectedAudibleOptions: unselectedAudibleOptionsPairs.map(first),
+                        selectedAudibleOption: selectedAudibleOptionPair?.0,
+                        unselectedLegibleOptions: unselectedLegibleOptionsPairs.map(first),
+                        selectedLegibleOption: selectedLegibleOptionsPair?.0)
+                    
+                    self.props?.didDiscoverMediaOptions(availableOptions)
+                }
+                
+            case .loading: break // Do nothing
+            case .loaded:
+                if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristicAudible) {
+                    let selectedOption = props?.selectedAudibleOption.flatMap {
+                        mediaOptionCache?.audibleOptions[$0]
+                    }
+                    
+                    item.select(selectedOption, in: group)
+                }
+                
+                if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristicLegible) {
+                    let selectedOption = props?.selectedLegibleOption.flatMap {
+                        mediaOptionCache?.legibleOptions[$0]
+                    }
+                    
+                    item.select(selectedOption, in: group)
+                }
+                
+            case .failed: break // Maybe we should notify failure via props?
+            case .cancelled: break}
+        }
+    }
+}

--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -18,17 +18,17 @@ extension UUIDPhantom {
 func first<T, U>(pair: (T, U)) -> T { return pair.0 }
 func second<T, U>(pair: (T, U)) -> U { return pair.1 }
 
-public struct Option: UUIDPhantom {
-    public let uuid: UUID
-    public let name: String
-    
-    public init(uuid: UUID = UUID(), name: String) {
-        self.uuid = uuid
-        self.name = name
-    }
-}
-
 public struct AvailableMediaOptions {
+    public struct Option: UUIDPhantom {
+        public let uuid: UUID
+        public let name: String
+        
+        public init(uuid: UUID = UUID(), name: String) {
+            self.uuid = uuid
+            self.name = name
+        }
+    }
+    
     public let unselectedAudibleOptions: [Option]
     public let selectedAudibleOption: Option?
     public let unselectedLegibleOptions: [Option]
@@ -36,6 +36,7 @@ public struct AvailableMediaOptions {
 }
 
 class MediaCharacteristicRenderer {
+    typealias Option = AvailableMediaOptions.Option
     
     struct Props {
         let item: AVPlayerItem

--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -35,7 +35,7 @@ public struct AvailableMediaOptions {
     public let selectedOption: Option?
 }
 
-class MediaCharacteristicRenderer {
+final class MediaCharacteristicRenderer {
     typealias Option = AvailableMediaOptions.Option
     
     struct Props {

--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -106,24 +106,19 @@ class MediaCharacteristicRenderer {
                         var legibleOptionsPairs = legibleOptions.map { option in
                             (Option(name: option.displayName), option)
                         }
-                        legibleOptionsPairs.insert((Option(name: "None"), AVMediaSelectionOption()), at: 0)
-                        self.mediaOptionCache?.legibleOptions = Dictionary(uniqueKeysWithValues: legibleOptionsPairs)
-                        let selectedLegibleOption = legibleGroup.flatMap { item.selectedMediaOption(in: $0) }
-                        let unselectedLegibleOptionsPairs = legibleOptionsPairs.filter {
-                            $0.1 != selectedLegibleOption
-                        }
                         // Selected 'None' as default
-                        let selectedLegibleOptionsPair = legibleOptionsPairs.first
+                        let selectedAudibleOptionPair = (Option(name: "None"), AVMediaSelectionOption())
+                        legibleOptionsPairs.insert(selectedAudibleOptionPair, at: 0)
+                        
+                        self.mediaOptionCache?.legibleOptions = Dictionary(uniqueKeysWithValues: legibleOptionsPairs)
                         return .init(
-                            unselectedOptions: unselectedLegibleOptionsPairs.map(first),
-                            selectedOption: selectedLegibleOptionsPair?.0)
+                            unselectedOptions: legibleOptionsPairs.map(first),
+                            selectedOption: selectedAudibleOptionPair.0)
                     }
-                    
                     
                     self.props?.didDiscoverAudibleOptions(audibleOptions())
                     self.props?.didDiscoverLegibleOptions(legibleOptions())
                 }
-                
             case .loading: break // Do nothing
             case .loaded:
                 if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristicAudible) {

--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -18,21 +18,21 @@ extension UUIDPhantom {
 func first<T, U>(pair: (T, U)) -> T { return pair.0 }
 func second<T, U>(pair: (T, U)) -> U { return pair.1 }
 
-public struct AudibleOption: UUIDPhantom {
-    public let uuid = UUID()
+public struct Option: UUIDPhantom {
+    public let uuid: UUID
     public let name: String
-}
-
-public struct LegibleOption: UUIDPhantom {
-    public let uuid = UUID()
-    public let name: String
+    
+    public init(uuid: UUID = UUID(), name: String) {
+        self.uuid = uuid
+        self.name = name
+    }
 }
 
 public struct AvailableMediaOptions {
-    let unselectedAudibleOptions: [AudibleOption]
-    let selectedAudibleOption: AudibleOption?
-    let unselectedLegibleOptions: [LegibleOption]
-    let selectedLegibleOption: LegibleOption?
+    public let unselectedAudibleOptions: [Option]
+    public let selectedAudibleOption: Option?
+    public let unselectedLegibleOptions: [Option]
+    public let selectedLegibleOption: Option?
 }
 
 class MediaCharacteristicRenderer {
@@ -41,14 +41,14 @@ class MediaCharacteristicRenderer {
         let item: AVPlayerItem
         let didStartMediaOptionsDiscovery: () -> ()
         let didDiscoverMediaOptions: (AvailableMediaOptions) -> ()
-        let selectedAudibleOption: AudibleOption?
-        let selectedLegibleOption: LegibleOption?
+        var selectedAudibleOption: Option?
+        var selectedLegibleOption: Option?
     }
     
     struct MediaOptionCache {
         let item: AVPlayerItem
-        var audibleOptions: [AudibleOption: AVMediaSelectionOption] = [:]
-        var legibleOptions: [LegibleOption: AVMediaSelectionOption] = [:]
+        var audibleOptions: [Option: AVMediaSelectionOption] = [:]
+        var legibleOptions: [Option: AVMediaSelectionOption] = [:]
     }
     
     var mediaOptionCache: MediaOptionCache?
@@ -82,11 +82,11 @@ class MediaCharacteristicRenderer {
                     let legibleOptions = legibleGroup?.options.filter(AVMediaSelectionOption.hasLanguageTag) ?? []
                     
                     let audibleOptionsPairs = audibleOptions.map { option in
-                        (AudibleOption(name: option.displayName), option)
+                        (Option(name: option.displayName), option)
                     }
                     
                     let legibleOptionsPairs = legibleOptions.map { option in
-                        (LegibleOption(name: option.displayName), option)
+                        (Option(name: option.displayName), option)
                     }
                     
                     self.mediaOptionCache = MediaOptionCache(

--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -47,14 +47,8 @@ extension Renderer {
         public var hasDuration: Bool
         public var pictureInPictureActive: Bool
         public var allowsExternalPlayback: Bool
-        public var audible: MediaSelection
-        public var legible: MediaSelection
-        
-        public enum MediaSelection {
-            case disabled
-            case off
-            case on(propertyList: Data)
-        }
+        public var audible: AudibleOption?
+        public var legible: LegibleOption?
         
         public init(angles: (vertical: Float, horizontal: Float),
                     content: URL,
@@ -64,8 +58,8 @@ extension Renderer {
                     hasDuration: Bool,
                     pictureInPictureActive: Bool,
                     allowsExternalPlayback: Bool,
-                    audible: MediaSelection,
-                    legible: MediaSelection) {
+                    audible: AudibleOption?,
+                    legible: LegibleOption?) {
             self.angles = angles
             self.content = content
             self.rate = rate
@@ -98,8 +92,8 @@ extension Renderer {
         case externalPlaybackAllowance(Bool)
         case externalPlaybackPossible(Bool)
         case averageVideoBitrateUpdated(Double)
-        case audibleSelectionGroup(MediaSelectionGroup)
-        case legibleSelectionGroup(MediaSelectionGroup)
+        case updateMediaOptions(AvailableMediaOptions)
+        case startDiscoveringMediaOptions
         
         public struct MediaSelectionGroup {
             public let selectedOption: AVMediaSelectionOption?

--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -47,8 +47,8 @@ extension Renderer {
         public var hasDuration: Bool
         public var pictureInPictureActive: Bool
         public var allowsExternalPlayback: Bool
-        public var audible: AudibleOption?
-        public var legible: LegibleOption?
+        public var audible: Option?
+        public var legible: Option?
         
         public init(angles: (vertical: Float, horizontal: Float),
                     content: URL,
@@ -58,8 +58,8 @@ extension Renderer {
                     hasDuration: Bool,
                     pictureInPictureActive: Bool,
                     allowsExternalPlayback: Bool,
-                    audible: AudibleOption?,
-                    legible: LegibleOption?) {
+                    audible: Option?,
+                    legible: Option?) {
             self.angles = angles
             self.content = content
             self.rate = rate

--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -39,6 +39,8 @@ public struct Renderer {
 
 extension Renderer {
     public struct Props {
+        public typealias Option = AvailableMediaOptions.Option
+        
         public var angles: (vertical: Float, horizontal: Float)
         public var content: URL
         public var rate: Float

--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -94,7 +94,8 @@ extension Renderer {
         case externalPlaybackAllowance(Bool)
         case externalPlaybackPossible(Bool)
         case averageVideoBitrateUpdated(Double)
-        case updateMediaOptions(AvailableMediaOptions)
+        case updateAudibleOptions(AvailableMediaOptions)
+        case updateLegibleOptions(AvailableMediaOptions)
         case startDiscoveringMediaOptions
         
         public struct MediaSelectionGroup {

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -82,6 +82,7 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
     
     private var timeObserver: Any?
     private var seekerController: SeekerController? = nil
+    private var mediaCharacteristicRenderer = MediaCharacteristicRenderer()
     private var pictureInPictureController: AnyObject?
     
     override public func loadView() {
@@ -123,6 +124,7 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                 observer = nil
                 pictureInPictureObserver = nil
                 seekerController = nil
+                mediaCharacteristicRenderer.props = nil
                 
                 return
             }
@@ -200,36 +202,15 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                     })
                 }
                 
+                let dispatch = self.dispatch
+                
                 if let item = player?.currentItem {
-                    let key = "availableMediaCharacteristicsWithMediaSelectionOptions"
-                    item.asset.loadValuesAsynchronously(forKeys: [key]) { [weak self] in
-                        var error: NSError? = nil
-                        let status = item.asset.statusOfValue(forKey: key, error: &error)
-                        guard case .loaded = status else { return }
-                        for characteristic in item.asset.availableMediaCharacteristicsWithMediaSelectionOptions {
-                            guard let group = item.asset.mediaSelectionGroup(
-                                forMediaCharacteristic: characteristic)
-                                else { return }
-                            let options: [AVMediaSelectionOption] = {
-                                guard characteristic == AVMediaCharacteristicLegible else { return group.options }
-                                return group.options.filter(AVMediaSelectionOption.hasLanguageTag)
-                            }()
-                            let selectedOption = item.selectedMediaOption(in: group)
-                            switch characteristic {
-                            case AVMediaCharacteristicAudible:
-                                self?.dispatch?(.audibleSelectionGroup(
-                                    .init(
-                                        selectedOption: selectedOption,
-                                        options: options)))
-                            case AVMediaCharacteristicLegible:
-                                self?.dispatch?(.legibleSelectionGroup(
-                                    .init(
-                                        selectedOption: selectedOption,
-                                        options: options)))
-                            default: break
-                            }
-                        }
-                    }
+                    mediaCharacteristicRenderer.props = MediaCharacteristicRenderer.Props(
+                        item: item,
+                        didStartMediaOptionsDiscovery: { dispatch?(.startDiscoveringMediaOptions) },
+                        didDiscoverMediaOptions: { dispatch?(.updateMediaOptions($0)) },
+                        selectedAudibleOption: props.audible,
+                        selectedLegibleOption: props.legible)
                 }
             }
     
@@ -286,34 +267,6 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                     }
                 }
             #endif
-            
-            func selectOption(for player: AVPlayer,
-                              characteristic: String,
-                              mediaSelection: Renderer.Props.MediaSelection) {
-                guard let item = currentPlayer.currentItem else { return }
-                guard let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) else { return }
-                switch mediaSelection {
-                case .on(let optionPropertyList):
-                    guard let propertyList = try? PropertyListSerialization
-                        .propertyList(from: optionPropertyList,
-                                      options: .mutableContainers,
-                                      format: nil) else { return }
-                    let mediaOption = group.mediaSelectionOption(withPropertyList: propertyList)
-                    guard mediaOption != item.selectedMediaOption(in: group) else { return }
-                    
-                    item.select(mediaOption, in: group)
-                case .off:
-                    item.select(nil, in: group)
-                case .disabled: break
-                }
-            }
-            
-            selectOption(for: currentPlayer,
-                         characteristic: AVMediaCharacteristicAudible,
-                         mediaSelection: props.audible)
-            selectOption(for: currentPlayer,
-                         characteristic: AVMediaCharacteristicLegible,
-                         mediaSelection: props.legible)
         }
     }
 }

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -214,7 +214,9 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                 }
             }
     
-
+            mediaCharacteristicRenderer.props?.selectedLegibleOption = props.legible
+            mediaCharacteristicRenderer.props?.selectedAudibleOption = props.audible
+            
             if currentPlayer.allowsExternalPlayback != props.allowsExternalPlayback {
                 currentPlayer.allowsExternalPlayback = props.allowsExternalPlayback
             }

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -208,7 +208,8 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                     mediaCharacteristicRenderer.props = MediaCharacteristicRenderer.Props(
                         item: item,
                         didStartMediaOptionsDiscovery: { dispatch?(.startDiscoveringMediaOptions) },
-                        didDiscoverMediaOptions: { dispatch?(.updateMediaOptions($0)) },
+                        didDiscoverAudibleOptions: { dispatch?(.updateAudibleOptions($0)) },
+                        didDiscoverLegibleOptions: { dispatch?(.updateLegibleOptions($0)) },
                         selectedAudibleOption: props.audible,
                         selectedLegibleOption: props.legible)
                 }


### PR DESCRIPTION
Move subtitles code to separate controller, store map of `UUID` to `Option` for UUID representable media options support. 

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-408)
