### PR TITLE
Remove 'view.window != nil'

### DIFF
--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -104,7 +104,7 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
     
     public var props: Renderer.Props? {
         didSet {
-            guard let props = props, view.window != nil else {
+            guard let props = props else {
                 if let timeObserver = timeObserver {
                     player?.removeTimeObserver(timeObserver)
                 }


### PR DESCRIPTION
@aol-public/mobile-sdk-team: Ready for review.

`view.window` can be `nil` when SFSafariViewController is appeared. In this case `player` will become `nil` and new AVPlayer will be generated. If AirPlay was turned on new AVPlayer instance leads to turning off of AirPlay.

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-495)
