### PR TITLE
Endless playback fixes

### DIFF
--- a/VideoRenderer/VideoRenderer/SeekerController.swift
+++ b/VideoRenderer/VideoRenderer/SeekerController.swift
@@ -12,13 +12,10 @@ public final class SeekerController {
     }
     
     public var currentTime: CMTime?
-    private var newTime: CMTime?
     private var activeSeekingTime: CMTime?
     
     public func process(to newTime: CMTime?) {
-        guard self.newTime != newTime else { return }
         guard self.currentTime != newTime else { return }
-        self.newTime = newTime
         self.currentTime = newTime
         
         guard let time = newTime else { return }

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -233,17 +233,13 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                     }
                 }
             }
-            
+    
+
             if currentPlayer.allowsExternalPlayback != props.allowsExternalPlayback {
                 currentPlayer.allowsExternalPlayback = props.allowsExternalPlayback
             }
             
             guard currentPlayer.currentItem?.status == .readyToPlay else { return }
-            
-            //            videoView?.resizeOptions = VideoStreamView.ResizeOptions(
-            //                allowVerticalBars: props.allowVerticalBars,
-            //                allowHorizontalBars: props.allowHorizontalBars
-            //            )
             
             func newDuration() -> CMTime? {
                 guard props.hasDuration == false, let item = currentPlayer.currentItem else { return nil }


### PR DESCRIPTION
`guard self.newTime != newTime else { return }`

This checks prevents seeking to the beginning after replay - newTime
never changes - happens only when we have no seeking activities during
content video playback

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-503)