### PR TITLE
Rework MediaCharacteristicRenderer logic

### DIFF
--- a/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
+++ b/VideoRenderer/VideoRenderer/MediaCharacteristicRenderer.swift
@@ -134,7 +134,7 @@ final class MediaCharacteristicRenderer {
 }
 
 extension Array {
-    internal func extend(element: Element, onTop: Bool = true) -> [Element] {
+    fileprivate func extend(element: Element, onTop: Bool = true) -> [Element] {
         var new = self
         onTop ? new.insert(element, at: 0) : new.append(element)
         return new


### PR DESCRIPTION
Old check for `item.asset.statusOfValue(::)` is not working because status `.unknown` appears once per item per player. So proposed to call `item.asset.loadValuesAsynchronously()` each time new item arrives because `item.asset.loadValuesAsynchronously()` will return immediately if `AVPlayer` has already downloaded it.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue 652](https://jira.ops.aol.com/browse/OMSDK-652) 
[JIRA Issue 651](https://jira.ops.aol.com/browse/OMSDK-651)