### PR TITLE
Added observers on AVPlayerItem values to detect video buffering

### DIFF
--- a/VideoRenderer/VideoRenderer/RendererRepository.swift
+++ b/VideoRenderer/VideoRenderer/RendererRepository.swift
@@ -97,6 +97,8 @@ extension Renderer {
         case playbackFinished
         case playbackReady
         case playbackFailed(Error)
+        case playbackLikelyToKeepUp(Bool)
+        case playbackBufferEmpty(Bool)
         
         case durationReceived(CMTime)
         case currentTimeUpdated(CMTime)

--- a/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
+++ b/VideoRenderer/VideoRenderer/VideoStreamViewController.swift
@@ -127,6 +127,10 @@ public final class VideoStreamViewController: UIViewController, RendererProtocol
                         self?.dispatch?(.playbackReady)
                     case .didChangeItemStatusToFailed(let error):
                         self?.dispatch?(.playbackFailed(error))
+                    case .didChangeItemPlaybackLikelyToKeepUp(let new):
+                        self?.dispatch?(.playbackLikelyToKeepUp(new))
+                    case .didChangeItemPlaybackBufferEmpty(let new):
+                        self?.dispatch?(.playbackBufferEmpty(new))
                     case .didChangeExternalPlaybackStatus(let status):
                         self?.dispatch?(.externalPlaybackPossible(status))
                     case .didChangeExternalPlaybackAllowance(let status):


### PR DESCRIPTION
## Changes
- Added observers on `playbackLikelyToKeepUp` and `playbackBufferEmpty` values to detect when we don't have anything in the buffer and to know when the buffer is ready and video is finally able to play.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-1788)